### PR TITLE
Fixed goreleaser to use golang 1.15

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
Use golang 1.15 in goreleaser builds.